### PR TITLE
WIP change HTML output to be more accessible

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -499,7 +499,7 @@
 <xsl:template match="c:list/@list-type"/>
 
 <xsl:template match="c:list[c:title]">
-  <div data-type="{local-name()}">
+  <div role="list">
     <!-- list-id-and-class will give it the class "list" at least -->
     <xsl:call-template name="list-id-and-class"/>
 
@@ -511,7 +511,7 @@
 </xsl:template>
 
 <xsl:template match="c:para//c:list[c:title][@display='inline']">
-  <span data-type="{local-name()}"><!-- list-id-and-class will give it the class "list" at least -->
+  <span role="list">
     <xsl:call-template name="list-id-and-class"/>
     <xsl:apply-templates select="c:title"/>
     <xsl:apply-templates mode="list-mode" select=".">
@@ -582,7 +582,7 @@
       <xsl:otherwise><xsl:value-of select="@list-type"/></xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
-  <div data-type="list" data-list-type="{$list-type}">
+  <div role="list" data-list-type="{$list-type}">
     <xsl:if test="$convert-id-and-class">
       <xsl:call-template name="list-id-and-class"/>
     </xsl:if>
@@ -598,7 +598,7 @@
       <xsl:otherwise><xsl:value-of select="@list-type"/></xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
-  <span data-type="list" data-list-type="{$list-type}">
+  <span role="list" data-list-type="{$list-type}">
     <xsl:if test="$convert-id-and-class">
       <xsl:call-template name="list-id-and-class"/>
     </xsl:if>
@@ -607,11 +607,11 @@
 </xsl:template>
 
 <xsl:template match="c:list[@display='inline']/c:item">
-  <span data-type="item"><xsl:apply-templates select="@*|node()"/></span>
+  <span role="listitem"><xsl:apply-templates select="@*|node()"/></span>
 </xsl:template>
 
 <xsl:template match="c:para//c:list[@display='block']/c:item|c:para//c:list[not(@display)]/c:item">
-  <div data-type="item"><xsl:apply-templates select="@*|node()"/></div>
+  <div role="listitem"><xsl:apply-templates select="@*|node()"/></div>
 </xsl:template>
 
 
@@ -639,11 +639,11 @@
 </xsl:template>
 
 <xsl:template match="c:emphasis[@effect='smallcaps']">
-  <span data-type="emphasis" class="smallcaps"><xsl:apply-templates select="@*|node()"/></span>
+  <span role="emphasis" class="smallcaps"><xsl:apply-templates select="@*|node()"/></span>
 </xsl:template>
 
 <xsl:template match="c:emphasis[@effect='normal']">
-  <span data-type="emphasis" class="normal"><xsl:apply-templates select="@*|node()"/></span>
+  <span role="emphasis" class="normal"><xsl:apply-templates select="@*|node()"/></span>
 </xsl:template>
 
 <!-- ========================= -->
@@ -665,7 +665,7 @@
   |c:term/@window"/>
 
 <xsl:template match="c:term[not(@url or @document or @target-id or @resource or @version)]" name="build-term">
-  <span data-type="term"><xsl:apply-templates select="@*|node()"/></span>
+  <dfn><xsl:apply-templates select="@*|node()"/></dfn>
 </xsl:template>
 
 <xsl:template match="c:term[@url or @document or @target-id or @resource or @version]">
@@ -932,7 +932,7 @@
 <xsl:template match="c:download/@src|c:download/@mime-type"/>
 
 <xsl:template match="c:download">
-  <a href="{@src}" data-media-type="{@mime-type}" data-type="{local-name()}">
+  <a href="{@src}" data-media-type="{@mime-type}" data-type="{local-name()}" aria-label="download link">
 
     <xsl:apply-templates select="@*|c:param"/>
     <xsl:apply-templates select="node()[not(self::c:param)]"/>

--- a/rhaptos/cnxmlutils/xsl/test/definition.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/definition.cnxml.html
@@ -46,32 +46,32 @@
     >Some of the properties of matter that you should know are:
       <div
         data-list-type='bulleted'
-        data-type='list'
         id='lid825'
+        role='list'
       >
         <div
           data-label='Strength'
-          data-type='item'
+          role='listitem'
         >Materials can be strong and resist bending (e.g. iron rods, cement) or weak (e.g. fabrics)</div>
         <div
           data-label='Thermal and electrical conductivity'
-          data-type='item'
+          role='listitem'
         >Materials that conduct heat (e.g. metals) are called thermal conductors. Materials that conduct electricity are electrical conductors.</div>
         <div
           data-label='Brittle, malleable or ductile'
-          data-type='item'
+          role='listitem'
         >Brittle materials break easily. Materials that are malleable can be easily formed into different shapes. Ductile materials are able to be formed into long wires.</div>
         <div
           data-label='Magnetic or non-magnetic'
-          data-type='item'
+          role='listitem'
         >Magnetic materials have a magnetic field.</div>
         <div
           data-label='Density'
-          data-type='item'
+          role='listitem'
         >Density is the mass per unit volume. An example of a dense material is concrete.</div>
         <div
           data-label='Boiling and melting points'
-          data-type='item'
+          role='listitem'
         >The boiling and melting points of substance help us to classify substances as solids, liquids or gases at a specific temperature.</div>
       </div>
     </p>
@@ -264,20 +264,20 @@ To separate something by 'mechanical means', means that there is no chemical pro
           <div
             data-list-type='enumerated'
             data-number-style='lower-alpha'
-            data-type='list'
             id='eip-id1167649056231'
+            role='list'
           >
             <div
-              data-type='item'
+              role='listitem'
             >sugar and water</div>
             <div
-              data-type='item'
+              role='listitem'
             >flour and iron filings (small pieces of iron)</div>
             <div
-              data-type='item'
+              role='listitem'
             >flour and baking powder</div>
             <div
-              data-type='item'
+              role='listitem'
             >smarties, jelly tots and peppermints</div>
           </div>
         </p>
@@ -683,17 +683,17 @@ For each of the following substances state whether it is a pure substance or a m
             <div
               data-list-type='enumerated'
               data-number-style='lower-alpha'
-              data-type='list'
               id='eip-id1167351497334'
+              role='list'
             >
               <div
-                data-type='item'
+                role='listitem'
               >Blood</div>
               <div
-                data-type='item'
+                role='listitem'
               >Argon</div>
               <div
-                data-type='item'
+                role='listitem'
               >Silicon dioxide (
                 <math
                   xmlns='http://www.w3.org/1998/Math/MathML'
@@ -705,7 +705,7 @@ For each of the following substances state whether it is a pure substance or a m
                 </math>)
               </div>
               <div
-                data-type='item'
+                role='listitem'
               >Sand and stones</div>
             </div>
           </p>
@@ -734,23 +734,23 @@ For each of the following substances state whether it is a pure substance or a m
         >Activity: Using models to represent substances</span>Use coloured balls and sticks to represent elements and compounds. Some examples that you can try to build are:
         <div
           data-list-type='bulleted'
-          data-type='list'
           id='eip-id1166921187210'
+          role='list'
         >
           <div
-            data-type='item'
+            role='listitem'
           >Hydrogen</div>
           <div
-            data-type='item'
+            role='listitem'
           >Oxygen</div>
           <div
-            data-type='item'
+            role='listitem'
           >Nitrogen</div>
           <div
-            data-type='item'
+            role='listitem'
           >Neon</div>
           <div
-            data-type='item'
+            role='listitem'
           >Sodium chloride (salt,
             <math
               xmlns='http://www.w3.org/1998/Math/MathML'
@@ -759,7 +759,7 @@ For each of the following substances state whether it is a pure substance or a m
             </math>)
           </div>
           <div
-            data-type='item'
+            role='listitem'
           >Potassium permanganate (
             <math
               xmlns='http://www.w3.org/1998/Math/MathML'
@@ -773,7 +773,7 @@ For each of the following substances state whether it is a pure substance or a m
             </math>)
           </div>
           <div
-            data-type='item'
+            role='listitem'
           >Water (
             <math
               xmlns='http://www.w3.org/1998/Math/MathML'
@@ -790,7 +790,7 @@ For each of the following substances state whether it is a pure substance or a m
             </math>)
           </div>
           <div
-            data-type='item'
+            role='listitem'
           >Iron sulphide (
             <math
               xmlns='http://www.w3.org/1998/Math/MathML'
@@ -1734,11 +1734,11 @@ For each of the following substances state whether it is a pure substance or a m
           <div
             data-list-type='enumerated'
             data-number-style='lower-alpha'
-            data-type='list'
             id='id734'
+            role='list'
           >
             <div
-              data-type='item'
+              role='listitem'
             >
               <math
                 xmlns='http://www.w3.org/1998/Math/MathML'
@@ -1753,7 +1753,7 @@ For each of the following substances state whether it is a pure substance or a m
               </math>
             </div>
             <div
-              data-type='item'
+              role='listitem'
             >
               <math
                 xmlns='http://www.w3.org/1998/Math/MathML'
@@ -1803,14 +1803,14 @@ For each of the following substances state whether it is a pure substance or a m
           <div
             data-list-type='enumerated'
             data-number-style='lower-alpha'
-            data-type='list'
             id='id87432'
+            role='list'
           >
             <div
-              data-type='item'
+              role='listitem'
             >sodium sulphate</div>
             <div
-              data-type='item'
+              role='listitem'
             >potassium chromate</div>
           </div>
         </p>
@@ -2429,20 +2429,20 @@ For each of the following substances state whether they are metals, metalloids o
           <div
             data-list-type='enumerated'
             data-number-style='lower-alpha'
-            data-type='list'
             id='eip-id1170734629720'
+            role='list'
           >
             <div
-              data-type='item'
+              role='listitem'
             >Oxygen</div>
             <div
-              data-type='item'
+              role='listitem'
             >Arsenic</div>
             <div
-              data-type='item'
+              role='listitem'
             >Vanadium</div>
             <div
-              data-type='item'
+              role='listitem'
             >Potassium</div>
           </div>
         </p>
@@ -2482,20 +2482,20 @@ For each of the following substances state whether they are metals, metalloids o
           <div
             data-list-type='enumerated'
             data-number-style='lower-alpha'
-            data-type='list'
             id='eip-id1170742635239'
+            role='list'
           >
             <div
-              data-type='item'
+              role='listitem'
             >Aluminium in a cooking pot</div>
             <div
-              data-type='item'
+              role='listitem'
             >Silicon in a computer chip</div>
             <div
-              data-type='item'
+              role='listitem'
             >Plastic insulation around a wire</div>
             <div
-              data-type='item'
+              role='listitem'
             >Silver jewellery</div>
           </div>
         </p>

--- a/rhaptos/cnxmlutils/xsl/test/emphasis.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/emphasis.cnxml.html
@@ -23,7 +23,7 @@
     <span
       class='smallcaps'
       data-effect='smallcaps'
-      data-type='emphasis'
+      role='emphasis'
     >quality</span> of
       the dessert depends on the ice cream, so do
     <em
@@ -33,7 +33,7 @@
     <span
       class='normal'
       data-effect='normal'
-      data-type='emphasis'
+      role='emphasis'
     >generic</span>brand.
   </p>
   <p

--- a/rhaptos/cnxmlutils/xsl/test/glossary.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/glossary.cnxml.html
@@ -73,10 +73,9 @@
     <p
       id='import-auto-id1170614065536'
     >This important relationship is known as
-      <span
-        data-type='term'
+      <dfn
         id='import-auto-id1170614061213'
-      >Ohm&#8217;s law</span>. It can be viewed as a cause-and-effect relationship, with voltage the cause and current the effect. This is an empirical law like that for friction&#8212;an experimentally observed phenomenon. Such a linear relationship doesn&#8217;t always occur.
+      >Ohm&#8217;s law</dfn>. It can be viewed as a cause-and-effect relationship, with voltage the cause and current the effect. This is an empirical law like that for friction&#8212;an experimentally observed phenomenon. Such a linear relationship doesn&#8217;t always occur.
     </p>
   </section>
   <section
@@ -89,10 +88,9 @@
     <p
       id='import-auto-id1170614065817'
     >If voltage drives current, what impedes it? The electric property that impedes current (crudely similar to friction and air resistance) is called
-      <span
-        data-type='term'
+      <dfn
         id='import-auto-id1170614065376'
-      >resistance</span>
+      >resistance</dfn>
       <math
         xmlns='http://www.w3.org/1998/Math/MathML'
       >

--- a/rhaptos/cnxmlutils/xsl/test/label.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/label.cnxml.html
@@ -21,7 +21,7 @@
     id='idm45791213868720'
   >
     <li
-      data-label='hello there'
+      data-label='hello&#10;          there&#10;        '
     >item</li>
   </ul>
 </body>

--- a/rhaptos/cnxmlutils/xsl/test/list.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/list.cnxml.html
@@ -23,8 +23,8 @@
       <li>list with item</li>
     </ul>
     <div
-      data-type='list'
       id='idm45159773375472'
+      role='list'
     >
       <div
         data-type='title'
@@ -49,8 +49,8 @@
         <li>and item</li>
       </ul>
       <div
-        data-type='list'
         id='idm45159773273792'
+        role='list'
       >
         <div
           data-type='title'
@@ -77,8 +77,8 @@
         id='idm45159773268624'
       >... bulleted lower-alpha</p>
       <div
-        data-type='list'
         id='idm45159773267920'
+        role='list'
       >
         <div
           data-type='title'
@@ -111,8 +111,8 @@
         <li>and item</li>
       </ul>
       <div
-        data-type='list'
         id='idm45159773261424'
+        role='list'
       >
         <div
           data-type='title'
@@ -136,8 +136,8 @@
         <li>list with all attributes</li>
       </ul>
       <div
-        data-type='list'
         id='idm45159773256016'
+        role='list'
       >
         <div
           data-type='title'
@@ -170,8 +170,8 @@
         <li>and item</li>
       </ol>
       <div
-        data-type='list'
         id='idm45159773249504'
+        role='list'
       >
         <div
           data-type='title'
@@ -195,8 +195,8 @@
         <li>list with all attributes</li>
       </ul>
       <div
-        data-type='list'
         id='idm45159773243568'
+        role='list'
       >
         <div
           data-type='title'
@@ -251,11 +251,11 @@
     >...
       <div
         data-list-type='bulleted'
-        data-type='list'
         id='idm45159773232832'
+        role='list'
       >
         <div
-          data-type='item'
+          role='listitem'
         >list with item</div>
       </div>...
     </p>
@@ -265,10 +265,10 @@
       <span
         data-display='inline'
         data-list-type='bulleted'
-        data-type='list'
+        role='list'
       >
         <span
-          data-type='item'
+          role='listitem'
         >list with item (inline)</span>
       </span>...
     </p>
@@ -276,18 +276,18 @@
       id='idm45159773229536'
     >...
       <div
-        data-type='list'
         id='idm45159773228976'
+        role='list'
       >
         <div
           data-type='title'
         >and title</div>
         <div
           data-list-type='bulleted'
-          data-type='list'
+          role='list'
         >
           <div
-            data-type='item'
+            role='listitem'
           >and item</div>
         </div>
       </div>...
@@ -296,7 +296,7 @@
       id='idm45159773227328'
     >...
       <span
-        data-type='list'
+        role='list'
       >
         <span
           data-type='title'
@@ -304,10 +304,10 @@
         <span
           data-display='inline'
           data-list-type='bulleted'
-          data-type='list'
+          role='list'
         >
           <span
-            data-type='item'
+            role='listitem'
           >and item (inline)</span>
         </span>
       </span>...
@@ -327,11 +327,11 @@
       >...
         <div
           data-list-type='bulleted'
-          data-type='list'
           id='idm45159773222640'
+          role='list'
         >
           <div
-            data-type='item'
+            role='listitem'
           >and item</div>
         </div>...
       </p>
@@ -341,10 +341,10 @@
         <span
           data-display='inline'
           data-list-type='bulleted'
-          data-type='list'
+          role='list'
         >
           <span
-            data-type='item'
+            role='listitem'
           >and item (inline)</span>
         </span>...
       </p>
@@ -352,18 +352,18 @@
         id='idm45159773219376'
       >...
         <div
-          data-type='list'
           id='idm45159773218816'
+          role='list'
         >
           <div
             data-type='title'
           >and title</div>
           <div
             data-list-type='bulleted'
-            data-type='list'
+            role='list'
           >
             <div
-              data-type='item'
+              role='listitem'
             >and item</div>
           </div>
         </div>...
@@ -372,7 +372,7 @@
         id='idm45159773217200'
       >...
         <span
-          data-type='list'
+          role='list'
         >
           <span
             data-type='title'
@@ -380,10 +380,10 @@
           <span
             data-display='inline'
             data-list-type='bulleted'
-            data-type='list'
+            role='list'
           >
             <span
-              data-type='item'
+              role='listitem'
             >and item (inline)</span>
           </span>
         </span>...
@@ -401,12 +401,12 @@
           data-mark-prefix='[PREFIX]'
           data-mark-suffix='[SUFFIX]'
           data-number-style='lower-alpha'
-          data-type='list'
           id='idm45159773213472'
+          role='list'
           start='3'
         >
           <div
-            data-type='item'
+            role='listitem'
           >list with all attributes</div>
         </div>...
       </p>
@@ -421,11 +421,11 @@
           data-mark-prefix='[PREFIX]'
           data-mark-suffix='[SUFFIX]'
           data-number-style='lower-alpha'
-          data-type='list'
+          role='list'
           start='3'
         >
           <span
-            data-type='item'
+            role='listitem'
           >list with all attributes (inline)</span>
         </span>...
       </p>
@@ -433,8 +433,8 @@
         id='idm45159773206432'
       >...
         <div
-          data-type='list'
           id='idm45159773205872'
+          role='list'
         >
           <div
             data-type='title'
@@ -447,11 +447,11 @@
             data-mark-prefix='[PREFIX]'
             data-mark-suffix='[SUFFIX]'
             data-number-style='lower-alpha'
-            data-type='list'
+            role='list'
             start='3'
           >
             <div
-              data-type='item'
+              role='listitem'
             >and item</div>
           </div>
         </div>...
@@ -460,7 +460,7 @@
         id='idm45159773202096'
       >...
         <span
-          data-type='list'
+          role='list'
         >
           <span
             data-type='title'
@@ -473,11 +473,11 @@
             data-mark-prefix='[PREFIX]'
             data-mark-suffix='[SUFFIX]'
             data-number-style='lower-alpha'
-            data-type='list'
+            role='list'
             start='3'
           >
             <span
-              data-type='item'
+              role='listitem'
             >and item (inline)</span>
           </span>
         </span>...
@@ -498,11 +498,11 @@
       >...
         <div
           data-list-type='bulleted'
-          data-type='list'
           id='idm45159773195392'
+          role='list'
         >
           <div
-            data-type='item'
+            role='listitem'
           >and item</div>
         </div>...
       </p>
@@ -512,10 +512,10 @@
         <span
           data-display='inline'
           data-list-type='bulleted'
-          data-type='list'
+          role='list'
         >
           <span
-            data-type='item'
+            role='listitem'
           >and item (inline)</span>
         </span>...
       </p>
@@ -523,18 +523,18 @@
         id='idm45159773191584'
       >...
         <div
-          data-type='list'
           id='idm45159773191024'
+          role='list'
         >
           <div
             data-type='title'
           >and title</div>
           <div
             data-list-type='bulleted'
-            data-type='list'
+            role='list'
           >
             <div
-              data-type='item'
+              role='listitem'
             >and item</div>
           </div>
         </div>...
@@ -543,7 +543,7 @@
         id='idm45159773189136'
       >...
         <span
-          data-type='list'
+          role='list'
         >
           <span
             data-type='title'
@@ -551,10 +551,10 @@
           <span
             data-display='inline'
             data-list-type='bulleted'
-            data-type='list'
+            role='list'
           >
             <span
-              data-type='item'
+              role='listitem'
             >and item (inline)</span>
           </span>
         </span>...
@@ -572,11 +572,11 @@
           data-list-type='bulleted'
           data-mark-prefix='[PREFIX]'
           data-mark-suffix='[SUFFIX]'
-          data-type='list'
           id='idm45159773185136'
+          role='list'
         >
           <div
-            data-type='item'
+            role='listitem'
           >list with all attributes</div>
         </div>...
       </p>
@@ -591,10 +591,10 @@
           data-list-type='bulleted'
           data-mark-prefix='[PREFIX]'
           data-mark-suffix='[SUFFIX]'
-          data-type='list'
+          role='list'
         >
           <span
-            data-type='item'
+            role='listitem'
           >list with all attributes (inline)</span>
         </span>...
       </p>
@@ -602,8 +602,8 @@
         id='idm45159773177552'
       >...
         <div
-          data-type='list'
           id='idm45159773176992'
+          role='list'
         >
           <div
             data-type='title'
@@ -616,10 +616,10 @@
             data-list-type='bulleted'
             data-mark-prefix='[PREFIX]'
             data-mark-suffix='[SUFFIX]'
-            data-type='list'
+            role='list'
           >
             <div
-              data-type='item'
+              role='listitem'
             >and item</div>
           </div>
         </div>...
@@ -628,7 +628,7 @@
         id='idm45159773172944'
       >...
         <span
-          data-type='list'
+          role='list'
         >
           <span
             data-type='title'
@@ -641,10 +641,10 @@
             data-list-type='bulleted'
             data-mark-prefix='[PREFIX]'
             data-mark-suffix='[SUFFIX]'
-            data-type='list'
+            role='list'
           >
             <span
-              data-type='item'
+              role='listitem'
             >and item (inline)</span>
           </span>
         </span>...
@@ -665,11 +665,11 @@
       >...
         <div
           data-list-type='enumerated'
-          data-type='list'
           id='idm45159773165968'
+          role='list'
         >
           <div
-            data-type='item'
+            role='listitem'
           >and item</div>
         </div>...
       </p>
@@ -679,10 +679,10 @@
         <span
           data-display='inline'
           data-list-type='enumerated'
-          data-type='list'
+          role='list'
         >
           <span
-            data-type='item'
+            role='listitem'
           >and item (inline)</span>
         </span>...
       </p>
@@ -690,18 +690,18 @@
         id='idm45159773162160'
       >...
         <div
-          data-type='list'
           id='idm45159773161600'
+          role='list'
         >
           <div
             data-type='title'
           >and title</div>
           <div
             data-list-type='enumerated'
-            data-type='list'
+            role='list'
           >
             <div
-              data-type='item'
+              role='listitem'
             >and item</div>
           </div>
         </div>...
@@ -710,7 +710,7 @@
         id='idm45159773159712'
       >...
         <span
-          data-type='list'
+          role='list'
         >
           <span
             data-type='title'
@@ -718,10 +718,10 @@
           <span
             data-display='inline'
             data-list-type='enumerated'
-            data-type='list'
+            role='list'
           >
             <span
-              data-type='item'
+              role='listitem'
             >and item (inline)</span>
           </span>
         </span>...
@@ -740,12 +740,12 @@
           data-mark-prefix='[PREFIX]'
           data-mark-suffix='[SUFFIX]'
           data-number-style='lower-alpha'
-          data-type='list'
           id='idm45159773155712'
+          role='list'
           start='3'
         >
           <div
-            data-type='item'
+            role='listitem'
           >list with all attributes</div>
         </div>...
       </p>
@@ -760,11 +760,11 @@
           data-mark-prefix='[PREFIX]'
           data-mark-suffix='[SUFFIX]'
           data-number-style='lower-alpha'
-          data-type='list'
+          role='list'
           start='3'
         >
           <span
-            data-type='item'
+            role='listitem'
           >list with all attributes (inline)</span>
         </span>...
       </p>
@@ -772,8 +772,8 @@
         id='idm45159773147856'
       >...
         <div
-          data-type='list'
           id='idm45159773147296'
+          role='list'
         >
           <div
             data-type='title'
@@ -786,11 +786,11 @@
             data-mark-prefix='[PREFIX]'
             data-mark-suffix='[SUFFIX]'
             data-number-style='lower-alpha'
-            data-type='list'
+            role='list'
             start='3'
           >
             <div
-              data-type='item'
+              role='listitem'
             >and item</div>
           </div>
         </div>...
@@ -799,7 +799,7 @@
         id='idm45159773143248'
       >...
         <span
-          data-type='list'
+          role='list'
         >
           <span
             data-type='title'
@@ -812,11 +812,11 @@
             data-mark-prefix='[PREFIX]'
             data-mark-suffix='[SUFFIX]'
             data-number-style='lower-alpha'
-            data-type='list'
+            role='list'
             start='3'
           >
             <span
-              data-type='item'
+              role='listitem'
             >and item (inline)</span>
           </span>
         </span>...
@@ -834,12 +834,12 @@
       >...
         <div
           data-list-type='labeled-item'
-          data-type='list'
           id='idm45159773136976'
+          role='list'
         >
           <div
             data-label='with a label'
-            data-type='item'
+            role='listitem'
           >and item</div>
         </div>...
       </p>
@@ -849,11 +849,11 @@
         <span
           data-display='inline'
           data-list-type='labeled-item'
-          data-type='list'
+          role='list'
         >
           <span
             data-label='with a label'
-            data-type='item'
+            role='listitem'
           >and item (inline)</span>
         </span>...
       </p>

--- a/rhaptos/cnxmlutils/xsl/test/term-and-link.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/term-and-link.cnxml.html
@@ -77,93 +77,73 @@
   <p
     id='p6'
   >
-    <span
-      data-type='term'
+    <dfn
       id='id012'
-    >with an id</span>
+    >with an id</dfn>
     <a
       data-to-term='true'
       href='http://cnx.org'
     >
-      <span
-        data-type='term'
-      >Custom
+      <dfn>Custom
         <strong>content</strong>
-      </span>
+      </dfn>
     </a>
     <a
       data-to-term='true'
       href='http://cnx.org'
     >
-      <span
-        data-type='term'
+      <dfn
         id='id013'
-      >with an id</span>
+      >with an id</dfn>
     </a>
     <a
       data-to-term='true'
       href='/m123'
     >
-      <span
-        data-type='term'
-      >to a module</span>
+      <dfn>to a module</dfn>
     </a>
     <a
       data-to-term='true'
       href='/m123#id456'
     >
-      <span
-        data-type='term'
-      >to an id in a module</span>
+      <dfn>to an id in a module</dfn>
     </a>
     <a
       data-to-term='true'
       href='/m123/resource.txt'
     >
-      <span
-        data-type='term'
-      >to a resource in a module</span>
+      <dfn>to a resource in a module</dfn>
     </a>
     <a
       data-to-term='true'
       href='/m123@1.1'
     >
-      <span
-        data-type='term'
-      >to a module version</span>
+      <dfn>to a module version</dfn>
     </a>
     <a
       data-to-term='true'
       href='/m123@1.1#id456'
     >
-      <span
-        data-type='term'
-      >to an id in a module version</span>
+      <dfn>to an id in a module version</dfn>
     </a>
     <a
       data-to-term='true'
       href='/m123@1.1/resource.txt'
     >
-      <span
-        data-type='term'
-      >to a resource in a module version</span>
+      <dfn>to a resource in a module version</dfn>
     </a>
     <a
       data-to-term='true'
       href='http://cnx.org'
     >
-      <span
-        data-type='term'
-      >in the same window</span>
+      <dfn>in the same window</dfn>
     </a>
     <a
       data-to-term='true'
       href='http://cnx.org'
       target='_window'
     >
-      <span
-        data-type='term'
-      >in a new window</span>
+      <dfn>in a new window</dfn>
     </a>
   </p>
 </body>

--- a/rhaptos/cnxmlutils/xsl/test/title.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/title.cnxml.html
@@ -53,8 +53,8 @@
     >Section Title</h3>
 <!-- This list should be a section, because it has a title. -->
     <div
-      data-type='list'
       id='listed-section-list'
+      role='list'
     >
       <div
         data-type='title'
@@ -90,8 +90,8 @@
         >subsection 1.1</h5>
 <!-- The list will now be created as a section of depth 4 -->
         <div
-          data-type='list'
           id='listed-subsectioned-list'
+          role='list'
         >
           <div
             data-type='title'
@@ -274,6 +274,7 @@ __enable_interrupt();
     //Enables general maskable interrupts
 ... the rest of your program
 }
+      
       </pre>
     </div>
 <!-- no c:preformat/c:title records exist in connextions-->


### PR DESCRIPTION
This changes the HTML output (when converting from CNXML) to be more accessible.

The gist of it is:

- convert `data-type=""` attributes to either `role=""` or `aria-label=""` attributes (This handles exercises, notes, examples, glossaries)
- convert `data-label=""` attributes to `aria-label=""` (this handles the custom “Feature” labels that are currently inside SVG

# Links

- https://www.w3.org/TR/wai-aria/roles#roles_categorization
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn

# Note on Travis Errors

The tests fail because I am coding in OSX and it seems lxml works differently or something. I tried running `./scripts/rebuild-tests` and I committed only the files that seemed to apply (but there were more).

So, could a linux code-reviewer could update the tests? 🙏 

# TODO

- [ ] lists that are converted to `<div>` or `<span>`
- [ ] add `aria-label="exercise"` to exercises and examples, instead of `data-type`
- [ ] in general, convert `data-type=` attributes to either `role=` or `aria-label=` attributes
- [ ] change `data-label=` attributes to `aria-label=`