### PR TITLE
update document titles to be h2

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -207,9 +207,9 @@
 <!-- ========================= -->
 
 <xsl:template match="/c:document/c:title">
-  <div data-type="document-title">
+  <h2 data-type="document-title">
     <xsl:apply-templates select="@*|node()"/>
-  </div>
+  </h2>
 </xsl:template>
 
 <xsl:template match="c:title|c:para//c:list[not(@display)]/c:title|c:para//c:list[@display='block']/c:title">

--- a/rhaptos/cnxmlutils/xsl/test/cite.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/cite.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Test Module</div>
+  >Test Module</h2>
   <p
     id='cite-example-1'
   >

--- a/rhaptos/cnxmlutils/xsl/test/classed.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/classed.cnxml.html
@@ -9,9 +9,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Document testing</div>
+  >Document testing</h2>
   <cnx-pi
     data-type='cnx.flag.introduction'
   >class="introduction flagged"</cnx-pi>

--- a/rhaptos/cnxmlutils/xsl/test/code.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/code.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Test Module</div>
+  >Test Module</h2>
   <pre
     data-display='block'
     id='idc23423423'

--- a/rhaptos/cnxmlutils/xsl/test/definition.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/definition.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Matter: Mixtures, compounds and elements</div>
+  >Matter: Mixtures, compounds and elements</h2>
   <section
     data-depth='1'
     data-element-type='intro'

--- a/rhaptos/cnxmlutils/xsl/test/emphasis.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/emphasis.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Test Emphasis</div>
+  >Test Emphasis</h2>
   <p
     id='emphexample'
   >

--- a/rhaptos/cnxmlutils/xsl/test/figure.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/figure.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Test Module</div>
+  >Test Module</h2>
   <figure
     id='idm45763482823568'
   >

--- a/rhaptos/cnxmlutils/xsl/test/footnote.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/footnote.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Footnote test</div>
+  >Footnote test</h2>
   <p
     id='idm46678431439360'
   >...</p>

--- a/rhaptos/cnxmlutils/xsl/test/glossary.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/glossary.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Ohm&#8217;s Law: Resistance and Simple Circuits</div>
+  >Ohm&#8217;s Law: Resistance and Simple Circuits</h2>
   <p
     id='import-auto-id1170614047950'
   >...</p>

--- a/rhaptos/cnxmlutils/xsl/test/label.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/label.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Test Module</div>
+  >Test Module</h2>
   <ul
     id='idm45791213869968'
   >

--- a/rhaptos/cnxmlutils/xsl/test/link.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/link.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Test Module</div>
+  >Test Module</h2>
   <p
     id='linkexample'
   >

--- a/rhaptos/cnxmlutils/xsl/test/list.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/list.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Test Module</div>
+  >Test Module</h2>
   <ol
     id='list-enumerated'
   >

--- a/rhaptos/cnxmlutils/xsl/test/media.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/media.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Test Module</div>
+  >Test Module</h2>
   <p
     id='idm46342028798864'
   >Audio and Video</p>

--- a/rhaptos/cnxmlutils/xsl/test/newline.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/newline.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Test Module</div>
+  >Test Module</h2>
   <p
     id='p1'
   >

--- a/rhaptos/cnxmlutils/xsl/test/note.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/note.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Test Module</div>
+  >Test Module</h2>
   <div
     data-type='note'
     id='id123'

--- a/rhaptos/cnxmlutils/xsl/test/para.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/para.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Test Module</div>
+  >Test Module</h2>
   <p
     id='keep1'
   >This test unwraps blockish elements (table, figure, list, etc) that are a child of a para.</p>

--- a/rhaptos/cnxmlutils/xsl/test/table.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/table.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Test Tables</div>
+  >Test Tables</h2>
   <section
     data-depth='1'
     id='section-1'

--- a/rhaptos/cnxmlutils/xsl/test/term-and-link.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/term-and-link.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Test Module</div>
+  >Test Module</h2>
   <p
     id='p1'
   >

--- a/rhaptos/cnxmlutils/xsl/test/title.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/title.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Document testing the use of the title tag</div>
+  >Document testing the use of the title tag</h2>
   <cnx-pi
     data-type='chapter-toc'
   >label="Learning Objectives"</cnx-pi>

--- a/rhaptos/cnxmlutils/xsl/test/xhtml-characters.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/xhtml-characters.cnxml.html
@@ -8,9 +8,9 @@
   xmlns:mod='http://cnx.rice.edu/#moduleIds'
   xmlns:qml='http://cnx.rice.edu/qml/1.0'
 >
-  <div
+  <h2
     data-type='document-title'
-  >Document testing the use of the title tag</div>
+  >Document testing the use of the title tag</h2>
   <p
     id='id1'
   >XHTML does not render Windows ISO characters at all. See


### PR DESCRIPTION
This fixes #147 . It updates the document title to be an `<h2>` rather than a `<div>` and updates the tests to match the new format.