### PR TITLE
convert all cnx:newline to span

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1390,9 +1390,7 @@
 </xsl:template>
 
 
-<xsl:template match="c:newline[not(parent::c:list)]
-                              [not(ancestor::c:para and @effect = 'underline')]
-                              [not(@effect) or @effect = 'underline' or @effect = 'normal']">
+<xsl:template match="c:newline[not(@effect) or @effect = 'underline' or @effect = 'normal']">
   <span data-type="{local-name()}">
 
     <xsl:apply-templates select="@*"/>

--- a/rhaptos/cnxmlutils/xsl/test/newline.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/newline.cnxml.html
@@ -25,13 +25,12 @@
     >
       <br></br>
     </span>
-    <div
-      class='not-converted-yet'
-    >NOT_CONVERTED_YET: newline</div>
-    <newline
+    <span
       data-effect='underline'
-      xmlns='http://cnx.rice.edu/cnxml'
-    ></newline>
+      data-type='newline'
+    >
+      <hr></hr>
+    </span>
     <span
       data-type='newline'
       id='id123'
@@ -46,31 +45,32 @@
       <br></br>
       <br></br>
     </span>
-    <div
-      class='not-converted-yet'
-    >NOT_CONVERTED_YET: newline</div>
-    <newline
+    <span
       data-effect='underline'
+      data-type='newline'
       id='id456'
-      xmlns='http://cnx.rice.edu/cnxml'
-    ></newline>
-    <div
-      class='not-converted-yet'
-    >NOT_CONVERTED_YET: newline</div>
-    <newline
+    >
+      <hr></hr>
+    </span>
+    <span
       data-count='3'
       data-effect='underline'
-      xmlns='http://cnx.rice.edu/cnxml'
-    ></newline>
-    <div
-      class='not-converted-yet'
-    >NOT_CONVERTED_YET: newline</div>
-    <newline
+      data-type='newline'
+    >
+      <hr></hr>
+      <hr></hr>
+      <hr></hr>
+    </span>
+    <span
       data-count='3'
       data-effect='underline'
+      data-type='newline'
       id='id789'
-      xmlns='http://cnx.rice.edu/cnxml'
-    ></newline>
+    >
+      <hr></hr>
+      <hr></hr>
+      <hr></hr>
+    </span>
   </p>
   <p
     id='idm46259579218000'
@@ -143,13 +143,12 @@
   <p
     id='idm46259579210640'
   >
-    <div
-      class='not-converted-yet'
-    >NOT_CONVERTED_YET: newline</div>
-    <newline
+    <span
       data-effect='underline'
-      xmlns='http://cnx.rice.edu/cnxml'
-    ></newline>
+      data-type='newline'
+    >
+      <hr></hr>
+    </span>
   </p>
   <ul
     id='idm46259579209984'


### PR DESCRIPTION
Only some newlines were being converted to a span. It seems like maybe they should all be converted to a span. 

If inline HTML tags are allowed everywhere in the XHTML spec then converting all should work.

Addresses https://github.com/Connexions/webview/issues/2131 and https://github.com/Connexions/webview/issues/1666 and https://github.com/Connexions/webview/issues/2112