### PR TITLE
No self closing tags v2

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -833,6 +833,19 @@
   <sup><xsl:apply-templates select="@*|node()"/><xsl:comment/></sup>
 </xsl:template>
 
+<!-- =========================================== -->
+<!-- XSLT processor libxslt suppresses comments. -->
+<!-- Put comments on every non self closing tag  -->
+<!-- without content.                            -->
+<!-- =========================================== -->
+
+<xsl:template name="apply-template-no-selfclose">
+  <xsl:param name="selection"/>
+  <xsl:apply-templates select="$selection"/>
+  <xsl:if test="not($selection)">
+    <xsl:comment> no-selfclose </xsl:comment>
+  </xsl:if>
+</xsl:template>
 
 <!-- ========================= -->
 <!-- Links: encode in @data-*  -->
@@ -1399,7 +1412,6 @@
   </span>
 </xsl:template>
 
-<!-- not covered elements (Marvin) -->
 
 <!-- ========================= -->
 <!-- Newline and Space -->

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -220,15 +220,17 @@
 
 <xsl:template match="/c:document/c:title">
   <div data-type="document-title">
-    <xsl:apply-templates select="@*|node()"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </div>
 </xsl:template>
 
 <xsl:template match="c:title|c:para//c:list[not(@display)]/c:title|c:para//c:list[@display='block']/c:title">
   <div data-type="title">
-    <xsl:apply-templates select="@*|node()"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </div>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1426,8 +1426,9 @@
 
 <xsl:template match="c:image[@for='pdf' or @for='Pdf']">
   <span data-media-type="{@mime-type}" data-print="true" data-src="{@src}" data-type="{local-name()}">
-    <xsl:apply-templates select="@*|node()"/>
-    <xsl:comment/> <!-- do not make span self closing when no children -->
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </span>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -233,7 +233,11 @@
 </xsl:template>
 
 <xsl:template match="c:para/c:title|c:table/c:title|c:para//c:title[not(parent::c:list)]|c:para//c:list[@display='inline']/c:title">
-  <span data-type="title"><xsl:apply-templates select="@*|node()"/><xsl:comment/></span>
+  <span data-type="title">
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </span>
 </xsl:template>
 
 <!-- ========================= -->
@@ -423,8 +427,9 @@
 
 <xsl:template match="c:example">
   <div data-type="{local-name()}">
-    <xsl:apply-templates select="@*|node()"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </div>
 </xsl:template>
 
@@ -434,8 +439,9 @@
 
 <xsl:template match="c:exercise">
   <div data-type="{local-name()}">
-    <xsl:apply-templates select="@*|node()"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </div>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -890,8 +890,9 @@
       </a>
       <xsl:text> </xsl:text>
       <span data-type="footnote-ref-content">
-        <xsl:apply-templates/>
-        <xsl:comment/>
+        <xsl:call-template name="apply-template-no-selfclose">
+          <xsl:with-param name="selection" select="node()"/>
+        </xsl:call-template>
       </span>
     </li>
 </xsl:template>

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -848,7 +848,6 @@
       <xsl:attribute name="target">_window</xsl:attribute>
     </xsl:if>
     <xsl:call-template name="build-term"/>
-    <xsl:comment/>
   </a>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -998,7 +998,6 @@
         <xsl:text>[link]</xsl:text>
       </xsl:otherwise>
     </xsl:choose>
-    <xsl:comment/>
   </a>
 </xsl:template>
 
@@ -1037,7 +1036,6 @@
             <xsl:text>[link]</xsl:text>
           </xsl:otherwise>
         </xsl:choose>
-        <xsl:comment/>
       </a>
     </xsl:when>
     <xsl:otherwise>

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1455,7 +1455,6 @@
       </xsl:if>
       <xsl:apply-templates select="@*|node()"/>
     </img>
-    <xsl:comment/>
   </a>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -447,22 +447,25 @@
 
 <xsl:template match="c:problem">
   <div data-type="{local-name()}">
-    <xsl:apply-templates select="@*|node()"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </div>
 </xsl:template>
 
 <xsl:template match="c:solution">
   <div data-type="{local-name()}">
-    <xsl:apply-templates select="@*|node()"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </div>
 </xsl:template>
 
 <xsl:template match="c:commentary">
   <div data-type="{local-name()}">
-    <xsl:apply-templates select="@*|node()"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </div>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -117,7 +117,7 @@
 <!-- Only consider c:titles in c:content (ignore c:document/c:title) -->
 <xsl:template match="c:title[ancestor::c:content]" priority="0">
   <xsl:message>TODO: <xsl:value-of select="local-name(..)"/>/<xsl:value-of select="local-name(.)"/></xsl:message>
-  <div class="not-converted-yet">NOT_CONVERTED_YET: <xsl:value-of select="local-name(..)"/>/<xsl:value-of select="local-name(.)"/><xsl:comment/></div>
+  <div class="not-converted-yet">NOT_CONVERTED_YET: <xsl:value-of select="local-name(..)"/>/<xsl:value-of select="local-name(.)"/></div>
   <xsl:copy>
     <xsl:apply-templates select="@*|node()"/>
   </xsl:copy>

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -931,6 +931,14 @@
   </xsl:if>
 </xsl:template>
 
+<xsl:template name="value-no-selfclose">
+  <xsl:param name="selection"/>
+  <xsl:value-of select="$selection"/>
+  <xsl:if test="not($selection)">
+    <xsl:call-template name='no-selfclose-comment'/>
+  </xsl:if>
+</xsl:template>
+
 <!-- ========================= -->
 <!-- Links: encode in @data-*  -->
 <!-- ========================= -->
@@ -1084,8 +1092,9 @@
 <xsl:template match="c:media">
   <span data-type="{local-name()}">
     <!-- Apply c:media optional attributes -->
-    <xsl:apply-templates select="@*|node()"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </span>
 </xsl:template>
 
@@ -1140,8 +1149,9 @@
     <xsl:apply-templates select="@*|c:param"/>
     <xsl:apply-templates select="node()[not(self::c:param)]"/>
     <!-- Link text -->
-    <xsl:value-of select="@src"/>
-    <xsl:comment/>
+    <xsl:call-template name="value-no-selfclose">
+      <xsl:with-param name="selection" select="@src"/>
+    </xsl:call-template>
   </a>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -29,11 +29,19 @@
 </xsl:template>
 
 <xsl:template match="c:div">
-  <div><xsl:apply-templates select="@*|node()"/><xsl:comment/></div>
+  <div>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </div>
 </xsl:template>
 
 <xsl:template match="c:span">
-  <span><xsl:apply-templates select="@*|node()"/><xsl:comment/></span>
+  <span>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </span>
 </xsl:template>
 
 <xsl:template match="c:document">
@@ -73,8 +81,9 @@
   <!-- Only render the abstract if it contains text/elements -->
   <xsl:if test="node()">
     <div data-type="abstract">
-      <xsl:apply-templates select="@*|node()"/>
-      <xsl:comment/>
+      <xsl:call-template name="apply-template-no-selfclose">
+        <xsl:with-param name="selection" select="@*|node()"/>
+      </xsl:call-template>
     </div>
   </xsl:if>
 </xsl:template>

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -915,11 +915,11 @@
   </sup>
 </xsl:template>
 
-<!-- =========================================== -->
-<!-- XSLT processor libxslt suppresses comments. -->
-<!-- Put comments on every non self closing tag  -->
-<!-- without content.                            -->
-<!-- =========================================== -->
+<!-- ================================================= -->
+<!-- XSLT processor libxslt suppresses empty comments. -->
+<!-- Put comments with text on every non self closing  -->
+<!-- tag without content.                              -->
+<!-- ================================================= -->
 
 <xsl:template name="no-selfclose-comment">
   <xsl:comment> no-selfclose </xsl:comment>

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -832,7 +832,11 @@
   |c:term/@window"/>
 
 <xsl:template match="c:term[not(@url or @document or @target-id or @resource or @version)]" name="build-term">
-  <span data-type="term"><xsl:apply-templates select="@*|node()"/><xsl:comment/></span>
+  <span data-type="term">
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </span>
 </xsl:template>
 
 <xsl:template match="c:term[@url or @document or @target-id or @resource or @version]">

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -898,11 +898,19 @@
 </xsl:template>
 
 <xsl:template match="c:sub">
-  <sub><xsl:apply-templates select="@*|node()"/><xsl:comment/></sub>
+  <sub>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </sub>
 </xsl:template>
 
 <xsl:template match="c:sup">
-  <sup><xsl:apply-templates select="@*|node()"/><xsl:comment/></sup>
+  <sup>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </sup>
 </xsl:template>
 
 <!-- =========================================== -->

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -798,11 +798,19 @@
 </xsl:template>
 
 <xsl:template match="c:emphasis[@effect='smallcaps']">
-  <span data-type="emphasis" class="smallcaps"><xsl:apply-templates select="@*|node()"/><xsl:comment/></span>
+  <span data-type="emphasis" class="smallcaps">
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </span>
 </xsl:template>
 
 <xsl:template match="c:emphasis[@effect='normal']">
-  <span data-type="emphasis" class="normal"><xsl:apply-templates select="@*|node()"/><xsl:comment/></span>
+  <span data-type="emphasis" class="normal">
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </span>
 </xsl:template>
 
 <!-- ========================= -->

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -471,21 +471,34 @@
 
 <xsl:template match="c:equation">
   <div data-type="{local-name()}">
-    <xsl:apply-templates select="@*|node()"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </div>
 </xsl:template>
 
 <xsl:template match="c:rule">
-  <div data-type="{local-name()}"><xsl:apply-templates select="@*|node()"/><xsl:comment/></div>
+  <div data-type="{local-name()}">
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </div>
 </xsl:template>
 
 <xsl:template match="c:statement">
-  <div data-type="{local-name()}"><xsl:apply-templates select="@*|node()"/><xsl:comment/></div>
+  <div data-type="{local-name()}">
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </div>
 </xsl:template>
 
 <xsl:template match="c:proof">
-  <div data-type="{local-name()}"><xsl:apply-templates select="@*|node()"/><xsl:comment/></div>
+  <div data-type="{local-name()}">
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </div>
 </xsl:template>
 
 <!-- ========================= -->
@@ -553,8 +566,9 @@
     <xsl:if test="c:label">
       <xsl:attribute name="data-has-label">true</xsl:attribute>
     </xsl:if>
-    <xsl:apply-templates select="@*|node()"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </div>
 </xsl:template>
 
@@ -589,7 +603,11 @@
 <!-- ========================= -->
 
 <xsl:template match="c:cite-title">
-  <span data-type="{local-name()}"><xsl:apply-templates select="@*|node()"/><xsl:comment/></span>
+  <span data-type="{local-name()}">
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </span>
 </xsl:template>
 
 <!-- ========================= -->

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1559,7 +1559,6 @@
       <xsl:with-param name="count" select="@count" />
       <xsl:with-param name="string" select="$string"/>
     </xsl:call-template>
-    <xsl:comment/>
   </span>
 </xsl:template>
 
@@ -1574,7 +1573,6 @@
       <xsl:with-param name="count" select="@count"/>
       <xsl:with-param name="string" select="' '"/>
     </xsl:call-template>
-    <xsl:comment/>
   </span>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1234,8 +1234,9 @@
 
 <xsl:template match="c:video[contains(@src, 'youtube')]">
   <iframe type="text/html" frameborder="0" src="{@src}" width="640" height="390">
-    <xsl:apply-templates select="@width|@height"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@width|@height"/>
+    </xsl:call-template>
   </iframe>
 </xsl:template>
 
@@ -1372,8 +1373,9 @@
 
 <xsl:template match="c:media[c:iframe]">
   <div data-type="{local-name()}">
-    <xsl:apply-templates select="@*|node()"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </div>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -755,21 +755,37 @@
 </xsl:template>
 
 <xsl:template match="c:list[@display='inline']/c:item">
-  <span data-type="item"><xsl:apply-templates select="@*|node()"/><xsl:comment/></span>
+  <span data-type="item">
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </span>
 </xsl:template>
 
 <!-- ========================= -->
 
 <xsl:template match="c:emphasis">
-  <strong><xsl:apply-templates select="@*[not(local-name()='effect')]|node()"/><xsl:comment/></strong>
+  <strong>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*[not(local-name()='effect')]|node()"/>
+    </xsl:call-template>
+  </strong>
 </xsl:template>
 
 <xsl:template match="c:emphasis[not(@effect) or @effect='bold' or @effect='Bold']">
-  <strong><xsl:apply-templates select="@*|node()"/><xsl:comment/></strong>
+  <strong>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </strong>
 </xsl:template>
 
 <xsl:template match="c:emphasis[@effect='italics' or @effect='italic']">
-  <em><xsl:apply-templates select="@*|node()"/><xsl:comment/></em>
+  <em>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </em>
 </xsl:template>
 
 <!-- Fix emphasis effect typo "italic" -->

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -125,7 +125,7 @@
 
 <xsl:template match="c:*" priority="-1">
   <xsl:message>TODO: <xsl:value-of select="local-name(.)"/></xsl:message>
-  <div class="not-converted-yet">NOT_CONVERTED_YET: <xsl:value-of select="local-name(.)"/><xsl:comment/></div>
+  <div class="not-converted-yet">NOT_CONVERTED_YET: <xsl:value-of select="local-name(.)"/></div>
   <xsl:copy>
     <xsl:apply-templates select="@*|node()"/>
   </xsl:copy>

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -496,7 +496,6 @@
     <xsl:apply-templates select="@id"/>
     <xsl:apply-templates select="c:title"/>
     <pre><xsl:apply-templates select="@*['id'!=local-name()]|node()[not(self::c:title)]"/></pre>
-    <xsl:comment/>
   </div>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -887,7 +887,6 @@
           <xsl:text>#footnote-ref</xsl:text><xsl:number level="any" count="c:footnote" format="1"/>
         </xsl:attribute>
         <xsl:number level="any" count="c:footnote" format="1"/>
-        <xsl:comment/>
       </a>
       <xsl:text> </xsl:text>
       <span data-type="footnote-ref-content">

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -875,7 +875,6 @@
       <xsl:number level="any" count="c:footnote" format="1"/>
       <xsl:comment/>
     </a>
-    <xsl:comment/>
   </sup>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -748,8 +748,9 @@
     <xsl:if test="$convert-id-and-class">
       <xsl:call-template name="list-id-and-class"/>
     </xsl:if>
-    <xsl:apply-templates select="@*['id' != local-name()]|node()[not(self::c:title)]"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*['id' != local-name()]|node()[not(self::c:title)]"/>
+    </xsl:call-template>
   </span>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -873,7 +873,6 @@
         <xsl:text>#footnote</xsl:text><xsl:number level="any" count="c:footnote" format="1"/>
       </xsl:attribute>
       <xsl:number level="any" count="c:footnote" format="1"/>
-      <xsl:comment/>
     </a>
   </sup>
 </xsl:template>

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -643,8 +643,8 @@
       <xsl:with-param name="convert-id-and-class" select="0"/>
     </xsl:apply-templates>
     <!-- test directly for content / non self closing tag because list-mode is used before -->
-    <xsl:if test="not(.)">
-      <xsl:call-template name='no-selfclose-comment'/>
+    <xsl:if test="not(node()[.])">
+      <xsl:call-template name="no-selfclose-comment"/>
     </xsl:if>
   </div>
 </xsl:template>
@@ -657,8 +657,8 @@
       <xsl:with-param name="convert-id-and-class" select="0"/>
     </xsl:apply-templates>
     <!-- test directly for content / non self closing tag because list-mode is used before -->
-    <xsl:if test="not(.)">
-      <xsl:call-template name='no-selfclose-comment'/>
+    <xsl:if test="not(node()[.])">
+      <xsl:call-template name="no-selfclose-comment"/>
     </xsl:if>
   </span>
 </xsl:template>
@@ -928,16 +928,16 @@
 <xsl:template name="apply-template-no-selfclose">
   <xsl:param name="selection"/>
   <xsl:apply-templates select="$selection"/>
-  <xsl:if test="not($selection)">
-    <xsl:call-template name='no-selfclose-comment'/>
+  <xsl:if test="not(node()[$selection])">
+    <xsl:call-template name="no-selfclose-comment"/>
   </xsl:if>
 </xsl:template>
 
 <xsl:template name="value-no-selfclose">
   <xsl:param name="selection"/>
   <xsl:value-of select="$selection"/>
-  <xsl:if test="not($selection)">
-    <xsl:call-template name='no-selfclose-comment'/>
+  <xsl:if test="not(node()[$selection])">
+    <xsl:call-template name="no-selfclose-comment"/>
   </xsl:if>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -856,7 +856,11 @@
 <!-- ========================= -->
 
 <xsl:template match="c:foreign[not(@url or @document or @target-id or @resource or @version)]">
-  <span data-type="{local-name()}"><xsl:apply-templates select="@*|node()"/><xsl:comment/></span>
+  <span data-type="{local-name()}">
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </span>
 </xsl:template>
 
 <xsl:template match="c:footnote">

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -640,7 +640,10 @@
     <xsl:apply-templates mode="list-mode" select=".">
       <xsl:with-param name="convert-id-and-class" select="0"/>
     </xsl:apply-templates>
-    <xsl:comment/>
+    <!-- test directly for content / non self closing tag because list-mode is used before -->
+    <xsl:if test="not(.)">
+      <xsl:call-template name='no-selfclose-comment'/>
+    </xsl:if>
   </div>
 </xsl:template>
 
@@ -651,7 +654,10 @@
     <xsl:apply-templates mode="list-mode" select=".">
       <xsl:with-param name="convert-id-and-class" select="0"/>
     </xsl:apply-templates>
-    <xsl:comment/>
+    <!-- test directly for content / non self closing tag because list-mode is used before -->
+    <xsl:if test="not(.)">
+      <xsl:call-template name='no-selfclose-comment'/>
+    </xsl:if>
   </span>
 </xsl:template>
 
@@ -875,11 +881,15 @@
 <!-- without content.                            -->
 <!-- =========================================== -->
 
+<xsl:template name="no-selfclose-comment">
+  <xsl:comment> no-selfclose </xsl:comment>
+</xsl:template>
+
 <xsl:template name="apply-template-no-selfclose">
   <xsl:param name="selection"/>
   <xsl:apply-templates select="$selection"/>
   <xsl:if test="not($selection)">
-    <xsl:comment> no-selfclose </xsl:comment>
+    <xsl:call-template name='no-selfclose-comment'/>
   </xsl:if>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1476,7 +1476,6 @@
     <xsl:apply-templates select="@*"/>
     <h3 data-type="glossary-title">Glossary</h3>
     <xsl:apply-templates select="node()"/>
-    <xsl:comment/>
   </div>
 </xsl:template>
 
@@ -1505,8 +1504,9 @@
 
 <xsl:template match="c:seealso">
   <span data-type="{local-name()}">
-    <xsl:apply-templates select="@*|node()"/>
-    <xsl:comment/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </span>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1460,7 +1460,11 @@
 
 
 <xsl:template match="c:iframe">
-  <iframe><xsl:apply-templates select="@*|node()"/><xsl:comment/></iframe>
+  <iframe>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </iframe>
 </xsl:template>
 
 <!-- ========================= -->

--- a/rhaptos/cnxmlutils/xsl/test/classed.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/classed.cnxml.html
@@ -42,7 +42,7 @@
       <strong
         data-effect='bold'
         id='Listing_1'
-      ></strong>Question 4.
+      ><!-- no-selfclose --></strong>Question 4.
     </div>
     <p
       id='pid6767'
@@ -61,7 +61,7 @@
       <strong
         data-effect='bold'
         id='Listing_2'
-      ></strong>Question 5.
+      ><!-- no-selfclose --></strong>Question 5.
     </div>
     <p
       id='pid234234'

--- a/rhaptos/cnxmlutils/xsl/test/definition.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/definition.cnxml.html
@@ -92,7 +92,7 @@
           data-src='CG10C1_001.eps'
           data-type='image'
           id='uid1_printimage'
-        ></span>
+        ><!-- no-selfclose --></span>
       </span>
     </figure>
   </section>
@@ -579,7 +579,7 @@ To separate something by 'mechanical means', means that there is no chemical pro
             data-src='CG10C1_003.eps'
             data-type='image'
             id='uid27_printimage'
-          ></span>
+          ><!-- no-selfclose --></span>
         </span>
       </figure>
       <p
@@ -2050,7 +2050,7 @@ To separate something by 'mechanical means', means that there is no chemical pro
                 data-src='CG10C1_004.eps'
                 data-type='image'
                 id='id65419_printimage'
-              ></span>
+              ><!-- no-selfclose --></span>
             </span>
           </figure>
           <ol

--- a/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml
@@ -7,8 +7,7 @@
 <content>
 <!-- image is missing in media here, no self closing span here -->
 <figure id="CNX_UPhysics_27_05_ChargeRC">
-<media id="fs-id1172099463127" alt="The figure shows four graphs of capacitor charging, with time on the x-axis. Parts a shows charge of the capacitor on the y-axis, the value increases from 0 to C&#949; and is equal to 0.632 C&#949; after 1 &#964;. Parts b shows current of the resistor on the y-axis, the value decreases from I subscript 0 to 0 and is equal to 0.368 I subscript 0 after 1 &#964;. Parts c shows voltage of the capacitor on the y-axis, the value increases from 0 to &#949; and is equal to 0.632 &#949; after 1 &#964;. Parts d shows voltage of the resistor on the y-axis, the value decreases from &#949; to 0 and is equal to 0.368 &#949; after 1 &#964;.">
-</media>
+<media id="fs-id1172099463127" alt="The figure shows four graphs of capacitor charging, with time on the x-axis. Parts a shows charge of the capacitor on the y-axis, the value increases from 0 to C&#949; and is equal to 0.632 C&#949; after 1 &#964;. Parts b shows current of the resistor on the y-axis, the value decreases from I subscript 0 to 0 and is equal to 0.368 I subscript 0 after 1 &#964;. Parts c shows voltage of the capacitor on the y-axis, the value increases from 0 to &#949; and is equal to 0.632 &#949; after 1 &#964;. Parts d shows voltage of the resistor on the y-axis, the value decreases from &#949; to 0 and is equal to 0.368 &#949; after 1 &#964;."></media>
 </figure>
 </content>
 </document>

--- a/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml
@@ -16,9 +16,10 @@
 <div id="test1a"></div>
 <div id="test1b">content2</div>
 <div><span></span></div>
+<div><span>content3</span></div>
 <div id="test1c"><span id="test1d"></span></div>
 <span></span>
 <span id="test1e"></span>
-<span id="test1f">content</span>
+<span id="test1f">content4</span>
 </content>
 </document>

--- a/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml
@@ -9,5 +9,16 @@
 <figure id="CNX_UPhysics_27_05_ChargeRC">
 <media id="fs-id1172099463127" alt="The figure shows four graphs of capacitor charging, with time on the x-axis. Parts a shows charge of the capacitor on the y-axis, the value increases from 0 to C&#949; and is equal to 0.632 C&#949; after 1 &#964;. Parts b shows current of the resistor on the y-axis, the value decreases from I subscript 0 to 0 and is equal to 0.368 I subscript 0 after 1 &#964;. Parts c shows voltage of the capacitor on the y-axis, the value increases from 0 to &#949; and is equal to 0.632 &#949; after 1 &#964;. Parts d shows voltage of the resistor on the y-axis, the value decreases from &#949; to 0 and is equal to 0.368 &#949; after 1 &#964;."></media>
 </figure>
+
+<!-- test for no-selfclose comment here -->
+<div></div>
+<div>content1</div>
+<div id="test1a"></div>
+<div id="test1b">content2</div>
+<div><span></span></div>
+<div id="test1c"><span id="test1d"></span></div>
+<span></span>
+<span id="test1e"></span>
+<span id="test1f">content</span>
 </content>
 </document>

--- a/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml.html
@@ -33,6 +33,9 @@
   <div>
     <span><!-- no-selfclose --></span>
   </div>
+  <div>
+    <span>content3</span>
+  </div>
   <div
     id='test1c'
   >
@@ -46,5 +49,5 @@
   ><!-- no-selfclose --></span>
   <span
     id='test1f'
-  >content</span>
+  >content4</span>
 </body>

--- a/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml.html
@@ -19,6 +19,6 @@
       data-alt='The figure shows four graphs of capacitor charging, with time on the x-axis. Parts a shows charge of the capacitor on the y-axis, the value increases from 0 to C&#949; and is equal to 0.632 C&#949; after 1 &#964;. Parts b shows current of the resistor on the y-axis, the value decreases from I subscript 0 to 0 and is equal to 0.368 I subscript 0 after 1 &#964;. Parts c shows voltage of the capacitor on the y-axis, the value increases from 0 to &#949; and is equal to 0.632 &#949; after 1 &#964;. Parts d shows voltage of the resistor on the y-axis, the value decreases from &#949; to 0 and is equal to 0.368 &#949; after 1 &#964;.'
       data-type='media'
       id='fs-id1172099463127'
-    ></span>
+    ><!-- no-selfclose --></span>
   </figure>
 </body>

--- a/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml.html
@@ -10,7 +10,7 @@
 >
   <div
     data-type='document-title'
-  ></div>
+  ><!-- no-selfclose --></div>
 <!-- image is missing in media here, no self closing span here -->
   <figure
     id='CNX_UPhysics_27_05_ChargeRC'

--- a/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/div_span_not_self_closing.cnxml.html
@@ -21,4 +21,30 @@
       id='fs-id1172099463127'
     ><!-- no-selfclose --></span>
   </figure>
+<!-- test for no-selfclose comment here -->
+  <div><!-- no-selfclose --></div>
+  <div>content1</div>
+  <div
+    id='test1a'
+  ><!-- no-selfclose --></div>
+  <div
+    id='test1b'
+  >content2</div>
+  <div>
+    <span><!-- no-selfclose --></span>
+  </div>
+  <div
+    id='test1c'
+  >
+    <span
+      id='test1d'
+    ><!-- no-selfclose --></span>
+  </div>
+  <span><!-- no-selfclose --></span>
+  <span
+    id='test1e'
+  ><!-- no-selfclose --></span>
+  <span
+    id='test1f'
+  >content</span>
 </body>

--- a/rhaptos/cnxmlutils/xsl/test/media.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/media.cnxml.html
@@ -282,7 +282,7 @@
       data-thumbnail='PhET_Icon.png'
       data-type='image'
       width='450'
-    ></span>
+    ><!-- no-selfclose --></span>
   </span>
   <p
     id='idm46342028761344'
@@ -318,7 +318,7 @@
         data-src='PhET_Icon.png'
         data-type='image'
         width='450'
-      ></span>
+      ><!-- no-selfclose --></span>
     </span>
   </figure>
   <p

--- a/rhaptos/cnxmlutils/xsl/test/para.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/para.cnxml.html
@@ -61,11 +61,11 @@
   <div
     data-type='note'
     id='keep11'
-  ></div>
+  ><!-- no-selfclose --></div>
   <div
     data-type='note'
     id='keep12'
-  ></div>
+  ><!-- no-selfclose --></div>
   <p>after</p>
   <p
     id='keep13'
@@ -73,12 +73,12 @@
   <div
     data-type='note'
     id='keep14'
-  ></div>
+  ><!-- no-selfclose --></div>
   <p>between</p>
   <div
     data-type='note'
     id='keep15'
-  ></div>
+  ><!-- no-selfclose --></div>
   <p>after</p>
   <table
     id='keep16'
@@ -130,7 +130,7 @@
   <div
     data-type='equation'
     id='keep22'
-  ></div>
+  ><!-- no-selfclose --></div>
   <p
     fo:font-weight='bold'
     id='xsl-fo-attributes'

--- a/rhaptos/cnxmlutils/xsl/test/problem_m58457_1.6.self_closing.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/problem_m58457_1.6.self_closing.cnxml.html
@@ -11,7 +11,7 @@
   <div
     data-type='document-title'
   >RC Circuits</div>
-  <div></div>
+  <div><!-- no-selfclose --></div>
   <p
     id='fs-id1172101891012'
   >When you use a flash camera, it takes a few seconds to charge the capacitor that powers the flash. The light flash discharges the capacitor in a tiny fraction of a second. Why does charging take longer than discharging? This question and several other phenomena that involve charging and discharging capacitors are discussed in this module.</p>

--- a/rhaptos/cnxmlutils/xsl/test/title.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/title.cnxml.html
@@ -403,7 +403,7 @@
       <strong
         data-effect='bold'
         id='Listing_1'
-      ></strong>Question 4.
+      ><!-- no-selfclose --></strong>Question 4.
     </div>
     <p
       id='idm45615968092288'


### PR DESCRIPTION
Rework of non self closing tags according to comment https://github.com/openstax/cnx/issues/280#issuecomment-498768481

Empty `<xsl:comment/>` tags are suppressed by the XSLT processor libxslt/xsltproc.
This has two problems:
- Relying on a specific XSLT processor is not the best practice (although I think libxslt will not be replaced anytime soon).
- suppressed comments are solving non-selfclosing tags only on 1 step conversions. As soon as two steps are involved (e.g. recipes or collections) this tags get again selfclosing on its own.

Therefore a new comment `<!-- no-selfclose -->` is only created in the output when there is no content inside the tag.