### PR TITLE
fix restructured text error in history.txt

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.6.0
 -----
 
-- Added new comment `<!-- no-selfclose -->` is only created in
+- Added new comment ``<!-- no-selfclose -->`` is only created in
 the output when there is no content inside the tag (#180)
 - Make self-closing tags mandatory for spans, div, iframe, etc. (#179)
 - Add utf-8 and math content to tests, check for self closing tags in tests (#178)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,7 @@ Changelog
 1.6.0
 -----
 
-- Added new comment ``<!-- no-selfclose -->`` is only created in
-the output when there is no content inside the tag (#180)
+- Added new comment `<!-- no-selfclose -->` is only created in the output when there is no content inside the tag (#180)
 - Make self-closing tags mandatory for spans, div, iframe, etc. (#179)
 - Add utf-8 and math content to tests, check for self closing tags in tests (#178)
 


### PR DESCRIPTION
use backticks for restructured text