### PR TITLE
Add "twine check" to travis tests

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Utilities to convert to and from CNXML - a lightweight XML markup
 language for marking up educational content in use by Connexions
 (http://cnx.org)
 
-To run transformations manually see *.sh script files manual-tests/
+To run transformations manually see `*.sh` script files manual-tests/
 Usually all test xml/html files are stored in rhaptos/cnxmlutils/tests/data/
 
 Develop

--- a/script/test
+++ b/script/test
@@ -3,3 +3,11 @@ cd "$(dirname "$0")/.." || exit 111
 source ./script/bootstrap || exit 111
 
 python setup.py test
+
+if [[ "${CI}" == "true" ]]
+then
+    # check the distribution
+    python setup.py bdist_wheel --universal
+    pip install twine
+    twine check dist/*
+fi


### PR DESCRIPTION
We have already created 2 releases that failed to upload to pypi because
of restructured text errors.  We should really check the distribution on
travis so we know in advance.