### PR TITLE
Fix README restructured text error from twine check

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Utilities to convert to and from CNXML - a lightweight XML markup
 language for marking up educational content in use by Connexions
 (http://cnx.org)
 
-To run transformations manually see *.sh script files manual-tests/
+To run transformations manually see `*.sh` script files manual-tests/
 Usually all test xml/html files are stored in rhaptos/cnxmlutils/tests/data/
 
 Develop


### PR DESCRIPTION
This is preventing us from uploading the package to pypi...

The error when running `twine check`:

```
line 8: Warning: Inline emphasis start-string without end-string.
line 8: Warning: Inline emphasis start-string without end-string.
```

It's probably referring to the `*` in `*.sh`.