### PR TITLE
More no self closing tag fixes

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1078,6 +1078,9 @@
     <xsl:apply-templates select="c:title"/>
     <xsl:apply-templates select="c:caption"/>
     <xsl:apply-templates select="node()[not(self::c:title or self::c:caption or self::c:label)]"/>
+    <xsl:if test="not(node())">
+      <xsl:call-template name="no-selfclose-comment"/>
+    </xsl:if>
   </figure>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1072,7 +1072,9 @@
 
 <xsl:template match="c:figure/c:caption|c:subfigure/c:caption">
   <figcaption>
-    <xsl:apply-templates select="@*|node()"/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
   </figcaption>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -266,6 +266,9 @@
     <xsl:apply-templates select="@*|node()">
       <xsl:with-param name="depth" select="$depth + 1"/>
     </xsl:apply-templates>
+    <xsl:if test="not(node())">
+      <xsl:call-template name="no-selfclose-comment"/>
+    </xsl:if>
   </section>
 </xsl:template>
 

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -943,7 +943,7 @@
 <xsl:template name="value-no-selfclose">
   <xsl:param name="selection"/>
   <xsl:value-of select="$selection"/>
-  <xsl:if test="not(node()[$selection])">
+  <xsl:if test="string-length($selection) = 0">
     <xsl:call-template name="no-selfclose-comment"/>
   </xsl:if>
 </xsl:template>

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -799,7 +799,11 @@
 </xsl:template>
 
 <xsl:template match="c:emphasis[@effect='underline']">
-  <u><xsl:apply-templates select="@*|node()"/></u>
+  <u>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="@*|node()"/>
+    </xsl:call-template>
+  </u>
 </xsl:template>
 
 <xsl:template match="c:emphasis[@effect='smallcaps']">

--- a/rhaptos/cnxmlutils/xsl/test/emphasis.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/emphasis.cnxml
@@ -5,7 +5,7 @@
     <para id="emphexample">
       In addition to bananas and ice cream, a
       <emphasis effect="underline">proper</emphasis> banana split requires whipped cream,
-      nuts,
+      nuts, <emphasis effect="underline"/>
       <emphasis>and</emphasis>
       cherries.  Remember that the
       <emphasis effect="smallcaps">quality</emphasis> of

--- a/rhaptos/cnxmlutils/xsl/test/emphasis.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/emphasis.cnxml.html
@@ -19,6 +19,9 @@
       data-effect='underline'
     >proper</u> banana split requires whipped cream,
       nuts,
+    <u
+      data-effect='underline'
+    ><!-- no-selfclose --></u>
     <strong>and</strong>
       cherries.  Remember that the
     <span

--- a/rhaptos/cnxmlutils/xsl/test/figure.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/figure.cnxml
@@ -19,6 +19,7 @@
     <code id="idm45763482819648">Text</code>
   </figure>
 
+  <figure id="empty-figure"/>
 
   <para id="idm45763482819056">Inside a para (make sure the title is a span, not a div):
     <figure id="idm45763482818720">

--- a/rhaptos/cnxmlutils/xsl/test/figure.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/figure.cnxml
@@ -20,6 +20,9 @@
   </figure>
 
   <figure id="empty-figure"/>
+  <figure id="no-caption">
+    <caption/>
+  </figure>
 
   <para id="idm45763482819056">Inside a para (make sure the title is a span, not a div):
     <figure id="idm45763482818720">

--- a/rhaptos/cnxmlutils/xsl/test/figure.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/figure.cnxml.html
@@ -39,6 +39,9 @@
       id='idm45763482819648'
     >Text</pre>
   </figure>
+  <figure
+    id="empty-figure"
+  ><!-- no-selfclose --></figure>
   <p
     id='idm45763482819056'
   >Inside a para (make sure the title is a span, not a div):</p>

--- a/rhaptos/cnxmlutils/xsl/test/figure.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/figure.cnxml.html
@@ -42,6 +42,11 @@
   <figure
     id="empty-figure"
   ><!-- no-selfclose --></figure>
+  <figure
+    id='no-caption'
+  >
+    <figcaption><!-- no-selfclose --></figcaption>
+  </figure>
   <p
     id='idm45763482819056'
   >Inside a para (make sure the title is a span, not a div):</p>

--- a/rhaptos/cnxmlutils/xsl/test/list.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/list.cnxml
@@ -55,6 +55,7 @@
           <title>list with all attributes and title</title>
           <item>and item</item>
         </list>
+        <section id="id-empty-section"/>
       </section>
       <section id="idm45159773264416">
         <title>Bulleted list:</title>

--- a/rhaptos/cnxmlutils/xsl/test/list.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/list.cnxml.html
@@ -137,6 +137,10 @@
           <li>and item</li>
         </ul>
       </div>
+      <section
+        data-depth='3'
+        id='id-empty-section'
+      ><!-- no-selfclose --></section>
     </section>
     <section
       data-depth='2'

--- a/rhaptos/cnxmlutils/xsl/test/media.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/media.cnxml
@@ -84,5 +84,10 @@
     </media>
   </figure>
 
+  <media id="course-syl" alt="Business Ethics Course Syllabus">
+    <download mime-type="application/msword" src="Business Ethics Spring 2007.doc"/>
+    <download mime-type="application/msword" src=""/>
+  </media>
+
 </content>
 </document>

--- a/rhaptos/cnxmlutils/xsl/test/media.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/media.cnxml.html
@@ -343,4 +343,20 @@
       ></img>
     </span>
   </figure>
+  <span
+    data-alt='Business Ethics Course Syllabus'
+    data-type='media'
+    id='course-syl'
+  >
+    <a
+      data-media-type='application/msword'
+      data-type='download'
+      href='Business Ethics Spring 2007.doc'
+    >Business Ethics Spring 2007.doc</a>
+    <a
+      data-media-type='application/msword'
+      data-type='download'
+      href=''
+    ><!-- no-selfclose --></a>
+  </span>
 </body>


### PR DESCRIPTION
- Add no self close comment to <section> in cnxml-to-html5

  Make sure `<section>` doesn't self close by adding a comment
  `<!-- no-selfclose -->` in it when there are no child nodes.

- Add no self close comment to <figure> in cnxml-to-html5

  Make sure `<figure>` doesn't self close by adding a comment
  `<!-- no-selfclose -->` in it when there are no child nodes.

- Add no self close comment to <u> in cnxml-to-html5

  Make sure `<u>` doesn't self close by adding a comment
  `<!-- no-selfclose -->` in it when there are no child nodes.

- Remove no self close comment for <a> where unnecessary

  For media downloads, if "src" is not empty, the link text is set to the
  src and there's no need to add the no self close comment.

- Add no self close comment to <figcaption> in cnxml-to-html5

  Make sure `<figcaption>` doesn't self close by adding a comment
  `<!-- no-selfclose -->` in it when there are no child nodes.

