### PR TITLE
Add self close comment to section titles h3 etc

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -252,6 +252,9 @@
     <xsl:element name="h{$depth+2}">
       <xsl:apply-templates mode="class" select="c:title"/>
       <xsl:apply-templates select="c:title/@*|c:title/node()"/>
+      <xsl:if test="c:title[not(node())]">
+        <xsl:call-template name="no-selfclose-comment"/>
+      </xsl:if>
     </xsl:element>
     <xsl:apply-templates select="node()[not(self::c:title or self::c:label)]">
       <xsl:with-param name="depth" select="$depth + 1"/>

--- a/rhaptos/cnxmlutils/xsl/test/title.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/title.cnxml
@@ -15,6 +15,10 @@
     <para id="id1164845159023">...</para>
   </section>
 
+  <section id="section-with-empty-title">
+    <title />
+  </section>
+
     <section id="listed-section">
       <title>Section Title</title>
       <!-- This list should be a section, because it has a title. -->

--- a/rhaptos/cnxmlutils/xsl/test/title.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/title.cnxml.html
@@ -47,6 +47,14 @@
   </section>
   <section
     data-depth='1'
+    id='section-with-empty-title'
+  >
+    <h3
+      data-type='title'
+    ><!-- no-selfclose --></h3>
+  </section>
+  <section
+    data-depth='1'
     id='listed-section'
   >
     <h3

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires = [
 if not IS_PY24:
     # Only list lxml as a dependency when outside the legacy context,
     # which is one that isn't running python >= 2.7.
-    install_requires.append('lxml')
+    install_requires.append('lxml>=4, <4.4')
 
 version = versioneer.get_version()
 


### PR DESCRIPTION
Section titles are sometimes empty in cnxml and that results in empty
`<h3>`, `<h4>`, `<h5>` etc that have no content.  Fix this by adding a
`<!-- no-selfclose -->` comment.

College physics has 2 of these empty section titles.  One is in
"Introduction to Applications of Nuclear Physics", first section on the
page.