### PR TITLE
Remove lxml version requirements for python 2.7 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.4"
+  - "3.5"
 addons:
   apt:
     packages:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,11 @@ install_requires = [
 if not IS_PY24:
     # Only list lxml as a dependency when outside the legacy context,
     # which is one that isn't running python >= 2.7.
-    install_requires.append('lxml>=4, <4.4')
+    if sys.version_info == (2, 7)  or sys.version_info >= (3, 5):
+        install_requires.append('lxml')
+    else:
+        # lxml 4.4.1 requires python 2.7, 3.5 or later.
+        install_requires.append('lxml>=4, <4.4')
 
 version = versioneer.get_version()
 


### PR DESCRIPTION
- Install lxml>=4, <4.4 only for python != 2.7 or < 3.5

  Having this in our setup.py causes lots of problems when installing
  other packages.  Pip doesn't try to resolve version conflicts.  If it
  installs lxml 4.4.1 (latest) as a dependency of some other package, and
  then it installs rhaptos.cnxmlutils, it outputs this error message:
  
  ```
  ERROR: rhaptos-cnxmlutils 1.7.1 has requirement lxml<4.4,>=4, but you'll
  have lxml 4.4.1 which is incompatible.
  ```
  
  We only need to have `lxml>=4, <4.4` for python != 2.7 or < 3.5.

- Change travis to use python 3.5 instead of 3.4

  It's not like we have any applications that's using 3.4, we originally
  added it to just make sure the code is python 3 compatible.  Since lxml
  4.4.1 doesn't work with 3.4, we're going to change the python version on
  travis.
