### PR TITLE
Fix lxml version in setup.py for python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires = [
 if not IS_PY24:
     # Only list lxml as a dependency when outside the legacy context,
     # which is one that isn't running python >= 2.7.
-    if sys.version_info == (2, 7)  or sys.version_info >= (3, 5):
+    if sys.version_info[:2] == (2, 7)  or sys.version_info >= (3, 5):
         install_requires.append('lxml')
     else:
         # lxml 4.4.1 requires python 2.7, 3.5 or later.


### PR DESCRIPTION
I intended for the lxml version to not be restricted when python 2.7 is
used but because of a mistake in the python 2.7 check:

```
sys.version_info == (2, 7)
```

it was always failing and ended up using the wrong lxml version.  This
is because `sys.version_info` has a micro version so it wasn't matching.

Fixed by doing:

```
sys.version_info[:2] == (2, 7)
```