### PR TITLE
Copy id attribute from CNXML table row entries

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -888,8 +888,8 @@
 </xsl:template>
 
 <!-- A footnote can occur as a child of any of the following so we need to handle all of these cases:
-     preformat, para, title, label, cite, cite-title, 
-     link, emphasis, term, sub, sup, quote, foreign, footnote, 
+     preformat, para, title, label, cite, cite-title,
+     link, emphasis, term, sub, sup, quote, foreign, footnote,
      note, item, code, caption, commentary, meaning, entry -->
 <xsl:template match="c:footnote">
   <a href="#{@id}" role="doc-noteref" epub:type="noteref">[footnote]</a>

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1743,6 +1743,9 @@
     <xsl:apply-templates mode="footnote-dumpsite" select="."/>
   </td>
 </xsl:template>
+<xsl:template match="c:entry/@id">
+  <xsl:copy/>
+</xsl:template>
 <!-- Discarded c:entry attributes -->
 <xsl:template match="c:entry/@*"/>
 <xsl:template match="c:entry/@align|c:entry/@valign">

--- a/rhaptos/cnxmlutils/xsl/test/table.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/table.cnxml
@@ -18,7 +18,7 @@
           </thead>
           <tfoot>
             <row>
-              <entry nameend="c2" namest="c1">
+              <entry nameend="c2" namest="c1" id="average">
 		Average:
               </entry>
               <entry>85.5%</entry>
@@ -26,7 +26,7 @@
           </tfoot>
           <tbody>
             <row>
-              <entry morerows="1">Biology</entry>
+              <entry morerows="1" id="biology">Biology</entry>
               <entry align="center">1</entry>
               <entry>86%</entry>
             </row>

--- a/rhaptos/cnxmlutils/xsl/test/table.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/table.cnxml.html
@@ -38,6 +38,7 @@
       <tfoot>
         <tr>
           <td
+            id='average'
             colspan='2'
           >Average:</td>
           <td>85.5%</td>
@@ -47,6 +48,7 @@
         <tr>
           <td
             rowspan='2'
+            id='biology'
           >Biology</td>
           <td
             data-align='center'


### PR DESCRIPTION
We had at least one book (Organizational Behavior) which uses an id
attribute in a CNXML table row entry which is referenced by a link.
The fact that the id attribute was being discarded led to a broken
link during validation of the final XHTML file.