### PR TITLE
Ensure footnotes with equations aren't dropped

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -275,7 +275,7 @@
 
 <!-- Help ensure that HTML paragraphs do not contain blockish elements as children -->
 
-<xsl:template match="c:para[not(.//c:figure|.//c:list[not(@display='inline')]|.//c:table|.//c:media[not(@display) or @display='block']|.//c:equation|.//c:preformat|.//c:note|.//c:exercise)]" name="convert-para">
+<xsl:template match="c:para[not(.//c:figure|.//c:list[not(@display='inline')]|.//c:table|.//c:media[not(@display) or @display='block']|.//c:equation[not(ancestor::c:footnote)]|.//c:preformat|.//c:note|.//c:exercise)]" name="convert-para">
   <p><xsl:apply-templates select="@*|node()"/></p>
   <xsl:apply-templates mode="footnote-dumpsite" select="."/>
 </xsl:template>

--- a/rhaptos/cnxmlutils/xsl/test/footnote.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/footnote.cnxml
@@ -41,6 +41,13 @@
     </footnote>
   </para>
 
+  <para>
+    Content with footnote
+    <footnote id="p5">
+      Footnote with equation: <equation id="eq1" class="unnumbered">x=2</equation>
+    </footnote>
+  </para>
+
   <note><!-- just to make sure the note doesn't also collect the footnotes -->
     <table>
       <title>

--- a/rhaptos/cnxmlutils/xsl/test/footnote.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/footnote.cnxml.html
@@ -125,6 +125,26 @@
       <li>Not sure what to do with lists</li>
     </ul>
   </aside>
+  <p>
+    Content with footnote
+    <a
+      epub:type='noteref'
+      href='#p5'
+      role='doc-noteref'
+    >[footnote]</a>
+  </p>
+  <aside
+    epub:type='footnote'
+    id='p5'
+    role='doc-footnote'
+  >
+      Footnote with equation:
+    <div
+      class='unnumbered'
+      data-type='equation'
+      id='eq1'
+    >x=2</div>
+  </aside>
   <div
     data-type='note'
   ><!-- just to make sure the note doesn't also collect the footnotes -->


### PR DESCRIPTION
This issue was discovered in Organizational Behavior where a footnote
link was broken due to the fact that the content was dropped during
transformation from CNXML to HTML. There is a predicate for ignoring
`<para>` elements when they contain `<equation>`s so the corresponding
HTML does not contain blockish elements as children. However, when
contained in a footnote, these elements get pulled out and wrapped
within an `<aside>` anyways so the existing check is overly strict.
This change adds an exception for these cases so equations can be
contained within `<para>` elements so long as they are contained
within a footnote.