### PR TITLE
fix msubsup

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -141,6 +141,10 @@
   </xsl:element>
 </xsl:template>
 
+<xsl:template match="m:msubsup[not(count(*)>1)]">
+  <xsl:apply-templates select="node()"/>
+</xsl:template>
+
 <xsl:template match="m:*">
   <xsl:element name="{local-name()}" namespace="http://www.w3.org/1998/Math/MathML">
     <xsl:apply-templates select="@*|node()"/>

--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -131,6 +131,16 @@
   </math>
 </xsl:template>
 
+<!-- ========================= -->
+<!-- Math Sanitization         -->
+<!-- ========================= -->
+
+<xsl:template match="m:msubsup[count(*)=2]">
+  <xsl:element name="msub" namespace="http://www.w3.org/1998/Math/MathML">
+    <xsl:apply-templates select="@*|node()"/>
+  </xsl:element>
+</xsl:template>
+
 <xsl:template match="m:*">
   <xsl:element name="{local-name()}" namespace="http://www.w3.org/1998/Math/MathML">
     <xsl:apply-templates select="@*|node()"/>

--- a/rhaptos/cnxmlutils/xsl/test/msubsup.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/msubsup.cnxml
@@ -23,5 +23,13 @@
         </msubsup>
     </math>
 
+    <para>This should unwrap the msubsup element because it contains at most one child (unlikely to occur):</para>
+
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+        <msubsup>
+            <mtext>Main text</mtext>
+        </msubsup>
+    </math>
+
 </content>
 </document>

--- a/rhaptos/cnxmlutils/xsl/test/msubsup.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/msubsup.cnxml
@@ -10,7 +10,6 @@
         <msubsup>
             <mtext>Main text</mtext>
             <mtext>Subscript</mtext>
-            <!-- <mtext>Superscript</mtext> -->
         </msubsup>
     </math>
 

--- a/rhaptos/cnxmlutils/xsl/test/msubsup.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/msubsup.cnxml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<document xmlns="http://cnx.rice.edu/cnxml" cnxml-version="0.7" id="id454" module-id="mXXXX">
+  <title>Test Module</title>
+
+<content>
+
+    <para>This should convert to a msub element:</para>
+
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+        <msubsup>
+            <mtext>Main text</mtext>
+            <mtext>Subscript</mtext>
+            <!-- <mtext>Superscript</mtext> -->
+        </msubsup>
+    </math>
+
+    <para>This should remain unchanged:</para>
+
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+        <msubsup>
+            <mtext>Main text</mtext>
+            <mtext>Subscript</mtext>
+            <mtext>Superscript</mtext>
+        </msubsup>
+    </math>
+
+</content>
+</document>

--- a/rhaptos/cnxmlutils/xsl/test/msubsup.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/msubsup.cnxml.html
@@ -1,0 +1,39 @@
+<body
+  data-cnxml-to-html-ver='v0.test'
+  xmlns='http://www.w3.org/1999/xhtml'
+  xmlns:bib='http://bibtexml.sf.net/'
+  xmlns:c='http://cnx.rice.edu/cnxml'
+  xmlns:data='http://www.w3.org/TR/html5/dom.html#custom-data-attribute'
+  xmlns:epub='http://www.idpf.org/2007/ops'
+  xmlns:md='http://cnx.rice.edu/mdml'
+  xmlns:mod='http://cnx.rice.edu/#moduleIds'
+  xmlns:qml='http://cnx.rice.edu/qml/1.0'
+>
+  <div
+    data-type='document-title'
+  >Test Module</div>
+  <p>This should convert to a msub element:</p>
+  <math
+    xmlns='http://www.w3.org/1998/Math/MathML'
+  >
+    <msub>
+      <mtext>Main text</mtext>
+      <mtext>Subscript</mtext>
+<!-- 
+  
+<mtext>Superscript
+</mtext>
+  -->
+    </msub>
+  </math>
+  <p>This should remain unchanged:</p>
+  <math
+    xmlns='http://www.w3.org/1998/Math/MathML'
+  >
+    <msubsup>
+      <mtext>Main text</mtext>
+      <mtext>Subscript</mtext>
+      <mtext>Superscript</mtext>
+    </msubsup>
+  </math>
+</body>

--- a/rhaptos/cnxmlutils/xsl/test/msubsup.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/msubsup.cnxml.html
@@ -19,11 +19,6 @@
     <msub>
       <mtext>Main text</mtext>
       <mtext>Subscript</mtext>
-<!-- 
-  
-<mtext>Superscript
-</mtext>
-  -->
     </msub>
   </math>
   <p>This should remain unchanged:</p>

--- a/rhaptos/cnxmlutils/xsl/test/msubsup.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/msubsup.cnxml.html
@@ -31,4 +31,10 @@
       <mtext>Superscript</mtext>
     </msubsup>
   </math>
+  <p>This should unwrap the msubsup element because it contains at most one child (unlikely to occur):</p>
+  <math
+    xmlns='http://www.w3.org/1998/Math/MathML'
+  >
+    <mtext>Main text</mtext>
+  </math>
 </body>


### PR DESCRIPTION
content occasionally contains msubsup with only 2 children but 3 are required (main, subscript, superscript). This converts the element to msub when there are only 2 children.

MathJax 2 performs this sanitization when rendering on REX or CNX which obscures the invalid content and the Relax-NG schema does not catch this (probably because the MathML Relax-NG is written to allow multiple children).

Check the content that contains msubsup elements. Here are the:

- [invalid ones in our content](https://openstax.github.io/sifter/?v=1&q=%2F%2Fm%3Amsubsup%5Bcount%28*%29%21%3D3%5D&code=&sourceFormat=cnxml) `//m:msubsup[count(*)!=3]`
- [valid ones in our content](https://openstax.github.io/sifter/?v=1&q=%2F%2Fm%3Amsubsup%5Bcount%28*%29%3D3%5D&code=&sourceFormat=cnxml) `//m:msubsup[count(*)=3]`