### PR TITLE
Adds HTML lang attribute when xml:lang attribute occurs

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -29,6 +29,11 @@
   <xsl:attribute name="data-{local-name()}"><xsl:value-of select="." /></xsl:attribute>
 </xsl:template>
 
+<xsl:template match="@xml:lang">
+  <xsl:copy/>
+  <xsl:attribute name="lang"><xsl:value-of select="." /></xsl:attribute>
+</xsl:template>
+
 <xsl:template match="c:div">
   <div>
     <xsl:call-template name="apply-template-no-selfclose">

--- a/rhaptos/cnxmlutils/xsl/test/build.py
+++ b/rhaptos/cnxmlutils/xsl/test/build.py
@@ -57,7 +57,7 @@ def html_to_cnxml():
 
         with open(filename, 'r') as input_, \
              open(trans_filename, 'w') as output:
-            output.write(xmlpp(transform(HTML2CNXML, xmlpp(input_.read()))))
+            output.write(xmlpp(transform(HTML2CNXML, xmlpp(str.encode(input_.read())))).decode('utf-8'))
 
 
 def cnxml_to_html():
@@ -69,7 +69,7 @@ def cnxml_to_html():
 
         with open(filename, 'r') as input_, \
              open(trans_filename, 'w') as output:
-            output.write(xmlpp(transform(CNXML2HTML, xmlpp(input_.read()))))
+            output.write(xmlpp(transform(CNXML2HTML, xmlpp(str.encode(input_.read())))).decode('utf-8'))
 
 
 def main(argv=None):

--- a/rhaptos/cnxmlutils/xsl/test/lang.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/lang.cnxml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<document xmlns="http://cnx.rice.edu/cnxml" cnxml-version="0.7" module-id="m12345">
+  <title>Test Module</title>
+  <content>
+    <para xml:lang="io">
+      la mikra hundo kuras en la foresto. <term xml:lang="eo">Esperanto</term>
+    </para>
+  </content>
+</document>

--- a/rhaptos/cnxmlutils/xsl/test/lang.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/lang.cnxml.html
@@ -1,0 +1,26 @@
+<body
+  data-cnxml-to-html-ver='v0.test'
+  xmlns='http://www.w3.org/1999/xhtml'
+  xmlns:bib='http://bibtexml.sf.net/'
+  xmlns:c='http://cnx.rice.edu/cnxml'
+  xmlns:data='http://www.w3.org/TR/html5/dom.html#custom-data-attribute'
+  xmlns:epub='http://www.idpf.org/2007/ops'
+  xmlns:md='http://cnx.rice.edu/mdml'
+  xmlns:mod='http://cnx.rice.edu/#moduleIds'
+  xmlns:qml='http://cnx.rice.edu/qml/1.0'
+>
+  <div
+    data-type='document-title'
+  >Test Module</div>
+  <p
+    lang='io'
+    xml:lang='io'
+  >
+      la mikra hundo kuras en la foresto.
+    <span
+      data-type='term'
+      lang='eo'
+      xml:lang='eo'
+    >Esperanto</span>
+  </p>
+</body>


### PR DESCRIPTION
The Polish books contain a few English terms which are marked up with a `<term xml:lang="en">` attribute. Screenreaders only recognize HTML lang attributes so this conversion adds the HTML lang attribute and keeps the xml:lang attribute.

/cc @TomWoodward