### PR TITLE
make links to exercises just a link

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1085,6 +1085,48 @@
   </a>
 </xsl:template>
 
+<!-- ==================================== -->
+<!-- Injected Exercises (they are a link) -->
+<!-- ==================================== -->
+
+<!-- Unwrap link in a para in a problem in an exercise so that all that remains is the link -->
+<xsl:template match="//c:exercise[.//c:link[contains(@target-id, 'ost/api/ex/') or contains(@url, '#exercise')]]">
+  <xsl:if test="count(.//c:link) != 1">
+    <xsl:message terminate="yes">Expected exactly 1 link to be in an embedded exercise (the link to where the embedded exercise is)</xsl:message>
+  </xsl:if>
+  <xsl:apply-templates select=".//c:link"/>
+</xsl:template>
+
+<xsl:template match="//c:link[contains(@target-id, 'ost/api/ex/')]/@target-id | //c:link[contains(@url, '#exercise/')]/@url">
+  <xsl:param name="exercise-id"/>
+  <xsl:variable name="search-string">
+    <xsl:choose>
+      <xsl:when test="contains(., '#exercise/')">
+        <xsl:value-of select="substring-after(., '#exercise/')"/>
+      </xsl:when>
+      <xsl:when test="contains(., 'ost/api/ex/')">
+        <xsl:value-of select="substring-after(., 'ost/api/ex/')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:message terminate="yes">Could not determine which format the injection-url has</xsl:message>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+  <xsl:variable name="id">
+    <xsl:value-of select="ancestor::c:exercise/@id"/>
+  </xsl:variable>
+  <xsl:if test="string-length($id) > 0">
+    <xsl:attribute name="id">
+      <xsl:value-of select="$id"/>
+    </xsl:attribute>
+  </xsl:if>
+  <xsl:attribute name="data-type">exercise-xref</xsl:attribute>
+  <xsl:attribute name="data-exercise-search-string">
+    <xsl:value-of select="$search-string"/>
+  </xsl:attribute>
+</xsl:template>
+
+
 <!-- dupped link code for cite to handle the no href case -->
 <!-- Attributes that are converted in some other way -->
 <xsl:template match="

--- a/rhaptos/cnxmlutils/xsl/test/exercise-injected.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/exercise-injected.cnxml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:bib="http://bibtexml.sf.net/" xmlns:md="http://cnx.rice.edu/mdml/0.4" xmlns:md1="http://cnx.rice.edu/mdml" xmlns:q="http://cnx.rice.edu/qml/1.0" cnxml-version="0.7" id="test" module-id="m12345">
+  <title>Test</title>
+  <content>
+    <exercise id="ex-id-1">
+        <problem id="prob-id-1">
+            <para id="para-id-1">
+                <link url="#exercise/searchstring123">link</link>
+            </para>
+        </problem>
+    </exercise>
+
+    <exercise id="ex-id-2">
+        <problem id="prob-id-2">
+            <para id="para-id-2">
+                <link target-id="ost/api/ex/searchstring234">link</link>
+            </para>
+        </problem>
+    </exercise>
+
+    <link url="#exercise/searchstring345">link</link>
+    <link target-id="ost/api/ex/searchstring456">link</link>
+  </content>
+</document>

--- a/rhaptos/cnxmlutils/xsl/test/exercise-injected.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/exercise-injected.cnxml.html
@@ -1,0 +1,37 @@
+<body
+  data-cnxml-to-html-ver='v0.test'
+  xmlns='http://www.w3.org/1999/xhtml'
+  xmlns:bib='http://bibtexml.sf.net/'
+  xmlns:c='http://cnx.rice.edu/cnxml'
+  xmlns:data='http://www.w3.org/TR/html5/dom.html#custom-data-attribute'
+  xmlns:epub='http://www.idpf.org/2007/ops'
+  xmlns:md='http://cnx.rice.edu/mdml'
+  xmlns:mod='http://cnx.rice.edu/#moduleIds'
+  xmlns:qml='http://cnx.rice.edu/qml/1.0'
+>
+  <div
+    data-type='document-title'
+  >Test</div>
+  <a
+    data-exercise-search-string='searchstring123'
+    data-type='exercise-xref'
+    href='#exercise/searchstring123'
+    id='ex-id-1'
+  >link</a>
+  <a
+    data-exercise-search-string='searchstring234'
+    data-type='exercise-xref'
+    href='#ost/api/ex/searchstring234'
+    id='ex-id-2'
+  >link</a>
+  <a
+    data-exercise-search-string='searchstring345'
+    data-type='exercise-xref'
+    href='#exercise/searchstring345'
+  >link</a>
+  <a
+    data-exercise-search-string='searchstring456'
+    data-type='exercise-xref'
+    href='#ost/api/ex/searchstring456'
+  >link</a>
+</body>


### PR DESCRIPTION
Now, when exercises get injected we can inject the problem and the solution. Previously it was just the problem because the link was inside the para which was inside the problem which was inside the exercise.

Also, this should simplify new books with exercises (CM's just add a `<link>` element instead of adding the boilerplate `<exercise><problem><para>`)