### PR TITLE
:bug: fix the pattern used to match embedded exercises

### DIFF
--- a/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
+++ b/rhaptos/cnxmlutils/xsl/cnxml-to-html5.xsl
@@ -1100,9 +1100,9 @@
 <!-- Unwrap link in a para in a problem in an exercise so that all that remains is the link -->
 <xsl:template match="//c:exercise[.//c:link[
   starts-with(@target-id, 'ost/api/ex/') or 
-  starts-with(@target-id, 'exercise') or 
+  starts-with(@target-id, 'exercise/') or 
   starts-with(@url, '#ost/api/ex/') or 
-  starts-with(@url, '#exercise')
+  starts-with(@url, '#exercise/')
   ]]">
   <xsl:if test="count(.//c:link) != 1">
     <xsl:call-template name="error-with-context">

--- a/rhaptos/cnxmlutils/xsl/test/exercise-injected.cnxml
+++ b/rhaptos/cnxmlutils/xsl/test/exercise-injected.cnxml
@@ -35,5 +35,14 @@
             </para>
         </problem>
     </exercise>
+
+    <exercise id="ex-id-5">
+        <problem id="prob-id-5">
+            <para id="para-id-5">
+                <link target-id="exercise-just-starts-with-the-word-but-does-not-have-a-slash-so-do-not-change-this">link</link>
+            </para>
+        </problem>
+    </exercise>
+
   </content>
 </document>

--- a/rhaptos/cnxmlutils/xsl/test/exercise-injected.cnxml.html
+++ b/rhaptos/cnxmlutils/xsl/test/exercise-injected.cnxml.html
@@ -46,4 +46,21 @@
     href='#exercise/searchstring678'
     id='ex-id-4'
   >link</a>
+  <div
+    data-type='exercise'
+    id='ex-id-5'
+  >
+    <div
+      data-type='problem'
+      id='prob-id-5'
+    >
+      <p
+        id='para-id-5'
+      >
+        <a
+          href='#exercise-just-starts-with-the-word-but-does-not-have-a-slash-so-do-not-change-this'
+        >link</a>
+      </p>
+    </div>
+  </div>
 </body>


### PR DESCRIPTION
This pattern was overly eager and would match any link that began with `exercise`. Instead, it should match any link that begins with `exercise/`

Refs https://github.com/openstax/cnx-recipes/issues/4507 and https://github.com/openstax/cnx-recipes/issues/4508